### PR TITLE
Twitter consumers keys will no longer be visible.

### DIFF
--- a/conf/taranis.conf.xml-dist
+++ b/conf/taranis.conf.xml-dist
@@ -115,10 +115,7 @@
   <testmode></testmode>
   <timeout>30</timeout>
   <toolsconfig>conf/taranis.conf.tools.xml</toolsconfig>
-  <twitter_consumer_key></twitter_consumer_key>
-  <twitter_consumer_secret></twitter_consumer_secret>
-  <twitter_access_token></twitter_access_token>
-  <twitter_access_token_secret></twitter_access_token_secret>
+  <twitter_bearer_token></twitter_bearer_token>
   <useragent_string>Mozilla/5.0 (Windows NT 6.1; rv:52.0) Gecko/20100101 Firefox/52.0</useragent_string>
   <webroot></webroot>
   <auto_send_eos>yes</auto_send_eos>

--- a/pm/Taranis/Collector/Twitter.pm
+++ b/pm/Taranis/Collector/Twitter.pm
@@ -37,14 +37,7 @@ sub getSourceData {
 
 	my $response = lwpRequest(
 		get => $retrieve_url,
-		lwp_constructor => sub {
-			LWP::Authen::OAuth->new(
-				oauth_consumer_key => $source->{oauth_consumer_key} || Config->{twitter_consumer_key},
-				oauth_consumer_secret => $source->{oauth_consumer_secret} || Config->{twitter_consumer_secret},
-				oauth_token => $source->{oauth_token} || Config->{twitter_access_token},
-				oauth_token_secret => $source->{oauth_token_secret} || Config->{twitter_access_token_secret},
-			);
-		},
+		Authorization => join ' ', 'Bearer',$source->{oauth_consumer_key} || Config->{twitter_bearer_token},
 	);
 
 	my $code = $self->{http_status_code} = $response->code;
@@ -147,7 +140,7 @@ sub collect {
 }
 
 sub getAdditionalConfigKeys {
-	return [ qw( oauth_consumer_key oauth_consumer_secret oauth_token oauth_token_secret) ];
+	return [ qw( oauth_consumer_key) ];
 }
 
 sub testCollector {
@@ -162,17 +155,10 @@ sub testCollector {
 
 	$fullurl .= $source->{url};
 
-	if ($source->{oauth_consumer_key} || Config->{twitter_consumer_key}) {
+	if ($source->{oauth_consumer_key} || Config->{twitter_bearer_token}) {
 		my $response = lwpRequest(
 			get => decode_entities( $fullurl ),
-			lwp_constructor => sub {
-				LWP::Authen::OAuth->new(
-					oauth_consumer_key => $source->{oauth_consumer_key} || Config->{twitter_consumer_key},
-					oauth_consumer_secret => $source->{oauth_consumer_secret} || Config->{twitter_consumer_secret},
-					oauth_token => $source->{oauth_token} || Config->{twitter_access_token},
-					oauth_token_secret => $source->{oauth_token_secret} || Config->{twitter_access_token_secret},
-				);
-			},
+			Authorization => join ' ', 'Bearer',$source->{oauth_consumer_key} || Config->{twitter_bearer_token},
 		);
 
 		if ( $response->is_success ) {


### PR DESCRIPTION
Twitter consumers keys will no longer be visible. we can use Bearer token instead with OAuth 2.0.
https://developer.twitter.com/en/docs/authentication/oauth-2-0/bearer-tokens

- Configuration file

We have changed `~/etc/taranis.conf.xml` from :
 ```
 <twitter_access_token></twitter_access_token>
  <twitter_access_token_secret></twitter_access_token_secret>
  <twitter_consumer_key></twitter_consumer_key>
  <twitter_consumer_secret></twitter_consumer_secret>
```
TO :

`<twitter_bearer_token></twitter_bearer_token>`

- Changing **Twitter.pm** 

Under `~/taranis-3.7.4/perl5/Taranis/Collector/Twitter.pm` we changed

```
my $response = lwpRequest(
		get => $retrieve_url,
		lwp_constructor => sub {
			LWP::Authen::OAuth->new(
				oauth_consumer_key => $source->{oauth_consumer_key} || Config->{twitter_consumer_key},
				oauth_consumer_secret => $source->{oauth_consumer_secret} || Config->{twitter_consumer_secret},
				oauth_token => $source->{oauth_token} || Config->{twitter_access_token},
				oauth_token_secret => $source->{oauth_token_secret} || Config->{twitter_access_token_secret},
			);
		},
	);

```
Into
```
my $response = lwpRequest(
			get => decode_entities( $fullurl ),
			Authorization => join ' ', 'Bearer',$source->{oauth_consumer_key} || Config->{twitter_bearer_token},
		);
```
## Test the new configuration

`taranis collector scan-sources --debug twitter`


P.N: The field should added to the web application interface too